### PR TITLE
Update gallery page with table content

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -361,7 +361,8 @@ class AdminController extends Controller
         if ($request->has('search') && $request->search) {
             $search = $request->search;
             $query->where(function($q) use ($search) {
-                $q->where('deskripsi', 'like', "%{$search}%")
+                $q->where('judul', 'like', "%{$search}%")
+                  ->orWhere('deskripsi', 'like', "%{$search}%")
                   ->orWhere('kategori', 'like', "%{$search}%");
             });
         }
@@ -383,16 +384,17 @@ class AdminController extends Controller
         AuthController::requireAdmin();
         
         $validated = $request->validate([
+            'judul' => 'nullable|string|max:255',
             'gambar' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
             'deskripsi' => 'nullable|string|max:500',
-            'tanggal_sewa' => 'required|date',
+            'tanggal_sewa' => 'nullable|date',
             'kategori' => 'nullable|string|max:50'
         ], [
+            'judul.max' => 'Judul maksimal 255 karakter.',
             'gambar.required' => 'Gambar wajib diupload.',
             'gambar.image' => 'File harus berupa gambar.',
             'gambar.mimes' => 'Format gambar harus JPG, PNG, atau GIF.',
             'gambar.max' => 'Ukuran gambar maksimal 2MB.',
-            'tanggal_sewa.required' => 'Tanggal sewa wajib diisi.',
             'tanggal_sewa.date' => 'Format tanggal tidak valid.'
         ]);
         
@@ -429,15 +431,16 @@ class AdminController extends Controller
         $galeri = \App\Models\Galeri::findOrFail($id);
         
         $validated = $request->validate([
+            'judul' => 'nullable|string|max:255',
             'gambar' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
             'deskripsi' => 'nullable|string|max:500',
-            'tanggal_sewa' => 'required|date',
+            'tanggal_sewa' => 'nullable|date',
             'kategori' => 'nullable|string|max:50'
         ], [
+            'judul.max' => 'Judul maksimal 255 karakter.',
             'gambar.image' => 'File harus berupa gambar.',
             'gambar.mimes' => 'Format gambar harus JPG, PNG, atau GIF.',
             'gambar.max' => 'Ukuran gambar maksimal 2MB.',
-            'tanggal_sewa.required' => 'Tanggal sewa wajib diisi.',
             'tanggal_sewa.date' => 'Format tanggal tidak valid.'
         ]);
         

--- a/database/seeders/GaleriSeeder.php
+++ b/database/seeders/GaleriSeeder.php
@@ -19,6 +19,7 @@ class GaleriSeeder extends Seeder
         $galeriData = [
             [
                 'id_admin' => $adminId,
+                'judul' => 'Motor Honda Beat 2022',
                 'gambar' => 'galeri/motor1.jpg',
                 'deskripsi' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
                 'tanggal_sewa' => '2021-03-25',
@@ -28,6 +29,7 @@ class GaleriSeeder extends Seeder
             ],
             [
                 'id_admin' => $adminId,
+                'judul' => 'Motor Yamaha Vixion',
                 'gambar' => 'galeri/motor2.jpg',
                 'deskripsi' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
                 'tanggal_sewa' => '2021-03-25',
@@ -37,6 +39,7 @@ class GaleriSeeder extends Seeder
             ],
             [
                 'id_admin' => $adminId,
+                'judul' => 'Wisata Pantai Malang',
                 'gambar' => 'galeri/wisata1.jpg',
                 'deskripsi' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
                 'tanggal_sewa' => '2021-03-25',
@@ -46,6 +49,7 @@ class GaleriSeeder extends Seeder
             ],
             [
                 'id_admin' => $adminId,
+                'judul' => 'Event Touring Bersama',
                 'gambar' => 'galeri/event1.jpg',
                 'deskripsi' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
                 'tanggal_sewa' => '2021-03-25',
@@ -55,6 +59,7 @@ class GaleriSeeder extends Seeder
             ],
             [
                 'id_admin' => $adminId,
+                'judul' => 'Dokumentasi Lainnya',
                 'gambar' => 'galeri/lainnya1.jpg',
                 'deskripsi' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
                 'tanggal_sewa' => '2021-03-25',

--- a/resources/views/admin/galeri.blade.php
+++ b/resources/views/admin/galeri.blade.php
@@ -37,7 +37,9 @@
                     <tr>
                         <th>No</th>
                         <th>Gambar</th>
+                        <th>Judul</th>
                         <th>Deskripsi</th>
+                        <th>Kategori</th>
                         <th>Tanggal Sewa</th>
                         <th>Tanggal Upload</th>
                         <th>Aksi</th>
@@ -61,11 +63,35 @@
                             @endif
                         </td>
                         <td>
+                            <div class="text-truncate" style="max-width: 150px;" title="{{ $item->judul }}">
+                                {{ $item->judul ?: '-' }}
+                            </div>
+                        </td>
+                        <td>
                             <div class="text-truncate" style="max-width: 200px;" title="{{ $item->deskripsi }}">
                                 {{ $item->deskripsi ?: 'Lorem Ipsum is simply dummy text' }}
                             </div>
                         </td>
-                        <td>{{ \Carbon\Carbon::parse($item->tanggal_sewa)->format('M d, Y') }}</td>
+                        <td>
+                            @if($item->kategori)
+                                <span class="badge bg-{{ 
+                                    $item->kategori == 'motor' ? 'primary' : 
+                                    ($item->kategori == 'wisata' ? 'success' : 
+                                    ($item->kategori == 'event' ? 'warning' : 'secondary')) 
+                                }}">
+                                    {{ ucfirst($item->kategori) }}
+                                </span>
+                            @else
+                                <span class="text-muted">-</span>
+                            @endif
+                        </td>
+                        <td>
+                            @if($item->tanggal_sewa)
+                                {{ \Carbon\Carbon::parse($item->tanggal_sewa)->format('M d, Y') }}
+                            @else
+                                <span class="text-muted">-</span>
+                            @endif
+                        </td>
                         <td>{{ \Carbon\Carbon::parse($item->created_at)->format('M d, Y') }}</td>
                         <td>
                             <div class="btn-group" role="group">
@@ -84,7 +110,7 @@
                     </tr>
                     @empty
                     <tr>
-                        <td colspan="6" class="text-center py-4">
+                        <td colspan="8" class="text-center py-4">
                             <i class="fas fa-images fa-3x text-muted mb-3"></i>
                             <p class="text-muted">Tidak ada data galeri</p>
                         </td>

--- a/resources/views/admin/galeri/create.blade.php
+++ b/resources/views/admin/galeri/create.blade.php
@@ -16,6 +16,16 @@
                 <div class="row">
                     <div class="col-md-6">
                         <div class="mb-3">
+                            <label for="judul" class="form-label">Judul</label>
+                            <input type="text" class="form-control @error('judul') is-invalid @enderror" 
+                                   id="judul" name="judul" value="{{ old('judul') }}" 
+                                   placeholder="Masukkan judul galeri...">
+                            @error('judul')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        
+                        <div class="mb-3">
                             <label for="gambar" class="form-label">Gambar</label>
                             <input type="file" class="form-control @error('gambar') is-invalid @enderror" 
                                    id="gambar" name="gambar" accept="image/*" required>
@@ -28,10 +38,11 @@
                         <div class="mb-3">
                             <label for="tanggal_sewa" class="form-label">Tanggal Sewa</label>
                             <input type="date" class="form-control @error('tanggal_sewa') is-invalid @enderror" 
-                                   id="tanggal_sewa" name="tanggal_sewa" value="{{ old('tanggal_sewa') }}" required>
+                                   id="tanggal_sewa" name="tanggal_sewa" value="{{ old('tanggal_sewa') }}">
                             @error('tanggal_sewa')
                                 <div class="invalid-feedback">{{ $message }}</div>
                             @enderror
+                            <small class="form-text text-muted">Opsional: Tanggal terkait dengan galeri ini.</small>
                         </div>
                     </div>
                     

--- a/resources/views/admin/galeri/edit.blade.php
+++ b/resources/views/admin/galeri/edit.blade.php
@@ -17,6 +17,16 @@
                 <div class="row">
                     <div class="col-md-6">
                         <div class="mb-3">
+                            <label for="judul" class="form-label">Judul</label>
+                            <input type="text" class="form-control @error('judul') is-invalid @enderror" 
+                                   id="judul" name="judul" value="{{ old('judul', $galeri->judul) }}" 
+                                   placeholder="Masukkan judul galeri...">
+                            @error('judul')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        
+                        <div class="mb-3">
                             <label for="gambar" class="form-label">Gambar</label>
                             <input type="file" class="form-control @error('gambar') is-invalid @enderror" 
                                    id="gambar" name="gambar" accept="image/*">
@@ -40,10 +50,11 @@
                             <label for="tanggal_sewa" class="form-label">Tanggal Sewa</label>
                             <input type="date" class="form-control @error('tanggal_sewa') is-invalid @enderror" 
                                    id="tanggal_sewa" name="tanggal_sewa" 
-                                   value="{{ old('tanggal_sewa', $galeri->tanggal_sewa) }}" required>
+                                   value="{{ old('tanggal_sewa', $galeri->tanggal_sewa) }}">
                             @error('tanggal_sewa')
                                 <div class="invalid-feedback">{{ $message }}</div>
                             @enderror
+                            <small class="form-text text-muted">Opsional: Tanggal terkait dengan galeri ini.</small>
                         </div>
                     </div>
                     


### PR DESCRIPTION
Adjust gallery page to fully align with the `galeri` database table structure, including `judul` and `kategori` fields, and making `tanggal_sewa` nullable.

The previous implementation of the gallery page did not fully utilize or correctly display all fields present in the `galeri` table (like `judul` and `kategori`), and `tanggal_sewa` was incorrectly marked as required. This PR updates the gallery index, create, and edit views, as well as the AdminController's validation and search logic, and the seeder, to correctly handle and display all relevant fields from the database, improving data integrity and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-4de366bf-45a3-4705-8eda-40f832970496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4de366bf-45a3-4705-8eda-40f832970496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>