### PR TITLE
Fix undefined requireAuth method

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -180,11 +180,23 @@ class AuthController extends Controller
     // === STATIC METHODS FOR OTHER CONTROLLERS ===
     // =========================
 
+    public static function requireAuth()
+    {
+        if (!session('is_logged_in')) {
+            abort(401, 'Anda harus login terlebih dahulu.');
+        }
+    }
+
     public static function requireAdmin()
     {
         if (session('user_role') !== 'admin') {
             abort(403, 'Akses ditolak. Hanya admin yang dapat mengakses halaman ini.');
         }
+    }
+
+    public static function isAdmin()
+    {
+        return session('user_role') === 'admin';
     }
 
     public static function getCurrentUser()


### PR DESCRIPTION
Add missing `requireAuth()` and `isAdmin()` static methods to `AuthController` to resolve undefined method errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd6d6c3-500c-4d00-8a7d-3a736e56aab1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bd6d6c3-500c-4d00-8a7d-3a736e56aab1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

